### PR TITLE
Add an assertion to fail tests ASAP if sample is nil

### DIFF
--- a/Fuzzer/Runners/FZRRunner.m
+++ b/Fuzzer/Runners/FZRRunner.m
@@ -18,6 +18,9 @@
 @implementation FZRRunner
 
 + (instancetype)runnerWithMutations:(NSArray <id <FZRMutation>> *)mutations forSample:(NSDictionary *)sample {
+    NSParameterAssert(mutations.count > 0);
+    NSParameterAssert(sample != nil);
+
     FZRRunner *runner = [FZRRunner new];
 
     runner.mutations = mutations;


### PR DESCRIPTION
Recently we realized that one of our tests actually tests nothing. While it's not a Fuzzer's fault, it'd be nice if it'd be failing immediately upon encountering a `nil` sample.

This PR also adds an assertion verifying that mutation list isn't empty.